### PR TITLE
Small logging enhancements (include traceback when logging exceptions, fix typos)

### DIFF
--- a/pypdl/pypdl_manager.py
+++ b/pypdl/pypdl_manager.py
@@ -143,12 +143,12 @@ class Pypdl:
         self._interrupt.set()
         self._stop = True
         time.sleep(1)
-        self.logger.debug("Download stoped")
+        self.logger.debug("Download stopped")
 
     def shutdown(self) -> None:
         """Shutdown the download manager."""
         self._pool.shutdown()
-        self.logger.debug("Shutdown download manger")
+        self.logger.debug("Shutdown download manager")
 
     def _reset(self):
         self._workers.clear()
@@ -165,7 +165,7 @@ class Pypdl:
         self.failed = False
         self.completed = False
         self.wait = True
-        self.logger.debug("Reseted download manager")
+        self.logger.debug("Reset download manager")
 
     def _execute(
         self, url, file_path, segments, display, multisegment, etag, overwrite
@@ -229,13 +229,13 @@ class Pypdl:
         header = asyncio.run(self._get_header(url))
         file_path = get_filepath(url, header, file_path)
         if size := int(header.get("content-length", 0)):
-            self.logger.debug("Size accquired from header")
+            self.logger.debug("Size acquired from header")
             self.size = size
 
         etag = header.get("etag", not etag)  # since we check truthiness of etag
 
         if isinstance(etag, str):
-            self.logger.debug("ETag accquired from header")
+            self.logger.debug("ETag acquired from header")
             etag = etag.strip('"')
 
         if not self.size or not header.get("accept-ranges"):
@@ -248,12 +248,12 @@ class Pypdl:
         async with aiohttp.ClientSession() as session:
             async with session.head(url, **self._kwargs) as response:
                 if response.status == 200:
-                    self.logger.debug("Header accquired from head request")
+                    self.logger.debug("Header acquired from head request")
                     return response.headers
 
             async with session.get(url, **self._kwargs) as response:
                 if response.status == 200:
-                    self.logger.debug("Header accquired from get request")
+                    self.logger.debug("Header acquired from get request")
                     return response.headers
 
     async def _multi_segment(self, segments, segment_table):
@@ -282,7 +282,7 @@ class Pypdl:
             self._workers.append(sd)
             try:
                 await sd.worker(url, file_path, session, **self._kwargs)
-                self.logger.debug("Downloaded single segement")
+                self.logger.debug("Downloaded single segment")
             except Exception as e:
                 self.logger.exception("(%s) [%s]", e.__class__.__name__, e)
                 self._interrupt.set()

--- a/pypdl/pypdl_manager.py
+++ b/pypdl/pypdl_manager.py
@@ -119,7 +119,7 @@ class Pypdl:
                     time.sleep(3)
 
                 except Exception as e:
-                    self.logger.error("(%s) [%s]", e.__class__.__name__, e)
+                    self.logger.exception("(%s) [%s]", e.__class__.__name__, e)
 
             self.wait = False
             self.failed = True
@@ -272,7 +272,7 @@ class Pypdl:
                 await asyncio.gather(*tasks)
                 self.logger.debug("Downloaded all segments")
             except Exception as e:
-                self.logger.error("(%s) [%s]", e.__class__.__name__, e)
+                self.logger.exception("(%s) [%s]", e.__class__.__name__, e)
                 self._interrupt.set()
 
     async def _single_segment(self, url, file_path):
@@ -284,7 +284,7 @@ class Pypdl:
                 await sd.worker(url, file_path, session, **self._kwargs)
                 self.logger.debug("Downloaded single segement")
             except Exception as e:
-                self.logger.error("(%s) [%s]", e.__class__.__name__, e)
+                self.logger.exception("(%s) [%s]", e.__class__.__name__, e)
                 self._interrupt.set()
 
     def _calc_values(self, recent_queue, interval):


### PR DESCRIPTION
Was tracking down a potential bug with multi-segment downloads and figured that when an error is logged while catching an exception, it should probably also log the traceback.

When an error occurred previously, only the following would be logged:

### pypdl.log
```
(Pypdl)  21-07-24 15:10:51 - ERROR: (AttributeError) ['NoneType' object has no attribute 'get']
```

With this PR, instead the following would be logged:

### pypdl.log
```
(Pypdl)  21-07-24 14:58:57 - ERROR: (AttributeError) ['NoneType' object has no attribute 'get']
Traceback (most recent call last):
  File "C:\Users\Speyedr\Documents\PyCharm Projects\pypdl-sticky-header-investigation\pypdl\pypdl_manager.py", line 103, in download
    result = self._execute(
             ^^^^^^^^^^^^^^
  File "C:\Users\Speyedr\Documents\PyCharm Projects\pypdl-sticky-header-investigation\pypdl\pypdl_manager.py", line 175, in _execute
    file_path, multisegment, etag = self._get_info(
                                    ^^^^^^^^^^^^^^^
  File "C:\Users\Speyedr\Documents\PyCharm Projects\pypdl-sticky-header-investigation\pypdl\pypdl_manager.py", line 230, in _get_info
    file_path = get_filepath(url, header, file_path)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\Speyedr\Documents\PyCharm Projects\pypdl-sticky-header-investigation\pypdl\utls.py", line 32, in get_filepath
    content_disposition = headers.get("Content-Disposition", None)
                          ^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'get'
```
This is an easy change that can help identify errornous code quicker in the future.

I have also fixed some small grammar mistakes and typos in the logging messages themselves.