### PR TITLE
fix #28: allow to set a custom download size

### DIFF
--- a/pypdl/pypdl_factory.py
+++ b/pypdl/pypdl_factory.py
@@ -177,7 +177,8 @@ class PypdlFactory:
     def _add_future(self, instance, task, futures):
         self.logger.debug("Adding new task")
         url, *kwargs = task
-        kwargs = {k: v for d in kwargs for k, v in d.items()}  # allow multiple parameters, like max_size
+        # allow multiple parameters, like max_size
+        kwargs = {k: v for d in kwargs for k, v in d.items()}
         kwargs.update({"block": False, "display": False, "overwrite": False})
         future = instance.start(url, **kwargs)
         futures[future] = (instance, url)

--- a/pypdl/pypdl_factory.py
+++ b/pypdl/pypdl_factory.py
@@ -177,7 +177,7 @@ class PypdlFactory:
     def _add_future(self, instance, task, futures):
         self.logger.debug("Adding new task")
         url, *kwargs = task
-        kwargs = kwargs[0] if kwargs else {}
+        kwargs = {k: v for d in kwargs for k, v in d.items()}  # allow multiple parameters, like max_size
         kwargs.update({"block": False, "display": False, "overwrite": False})
         future = instance.start(url, **kwargs)
         futures[future] = (instance, url)

--- a/pypdl/pypdl_manager.py
+++ b/pypdl/pypdl_manager.py
@@ -117,7 +117,7 @@ class Pypdl:
             block (bool, optional):
                 Whether to block the function until the download is complete. Default is `True`.
 
-            max_size (bool, int):
+            max_size (int, optional):
                 The max number of bytes to download(video). Default is None.
 
         Returns:

--- a/pypdl/pypdl_manager.py
+++ b/pypdl/pypdl_manager.py
@@ -42,7 +42,8 @@ class Pypdl:
         self._interrupt = Event()
         self._stop = False
         self._kwargs = {
-            "allow_redirects": True,  # avoid redirected requests that don't get the content-length
+            # avoid redirected requests that don't get the content-length
+            "allow_redirects": True,
             "timeout": aiohttp.ClientTimeout(sock_read=60),
             "raise_for_status": True,
         }
@@ -270,7 +271,7 @@ class Pypdl:
 
                 time.sleep(interval)
 
-    def _get_info(self, url, file_path, multisegment, etag, max_size: Optional[int] = None):
+    def _get_info(self, url, file_path, multisegment, etag, max_size=None):
         header = asyncio.run(self._get_header(url))
         file_path = get_filepath(url, header, file_path)
         if size := int(header.get("content-length", 0)):


### PR DESCRIPTION
Fix #28
Add `max_size` parameter to limit the size of the download file.

Use example, For single file download:
```python
dl.start(
    url='https://speed.hetzner.de/100MB.bin',
    file_path='100MB.bin',
    multisegment=True,
    segments=20,
    overwrite=False,
    etag=True,
    retries=5,
    mirror_func=None,
    display=True,
    clear_terminal=True,
    block=True,
    max_size=52428800,  # 50MB
)
```
For multiple files download concurrently:
```python
factory = PypdlFactory(instances=5, allow_reuse=True, proxy=proxy)
tasks = [
    ('https://example.com/file1.zip', {'file_path': 'file1.zip', 'max_size': 52428800}),  # each file can be customized
    ('https://example.com/file2.zip', {'file_path': 'file2.zip', 'max_size': 5242880}),
    ('https://example.com/file3.zip', {'file_path': 'file3.zip', 'max_size': 524288}),
    ('https://example.com/file4.zip', {'file_path': 'file4.zip', 'max_size': 5242880}),
    ('https://example.com/file5.zip', {'file_path': 'file5.zip', 'max_size': 52428800}),
]
results = factory.start(tasks, display=True, block=False)
```